### PR TITLE
migrate dart to null-safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+### 1.0.0 - 10/25/2021
+  * NullSafety support
 ### 0.1.2 - 09/21/202
 
   * Add buffer for chunks of one RSocket Frame

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 format:
-   dartfmt -w lib test
+   dart format lib test
 
 server:
    rsocket-cli -i "pong" --server --debug tcp://localhost:42252

--- a/lib/core/rsocket_error.dart
+++ b/lib/core/rsocket_error.dart
@@ -1,5 +1,5 @@
 class RSocketException implements Exception {
-  final int code;
+  final int? code;
   final String message;
 
   RSocketException(this.code, this.message);

--- a/lib/core/rsocket_responder.dart
+++ b/lib/core/rsocket_responder.dart
@@ -8,11 +8,11 @@ import '../payload.dart';
 import '../rsocket.dart';
 
 class BaseResponder {
-  SocketAcceptor socketAcceptor;
-  Uri uri;
+  late SocketAcceptor socketAcceptor;
+  late Uri uri;
 
   Future<void> receiveConnection(DuplexConnection duplexConn) async {
-    RSocketRequester rsocketRequester;
+    RSocketRequester? rsocketRequester;
     duplexConn.receiveHandler = (chunk) {
       for (var frame in parseFrames(chunk)) {
         var header = frame.header;
@@ -45,7 +45,7 @@ class BaseResponder {
 }
 
 class TcpRSocketResponder extends BaseResponder implements Closeable {
-  ServerSocket serverSocket;
+  late ServerSocket serverSocket;
 
   TcpRSocketResponder(
       Uri uri, ServerSocket serverSocket, SocketAcceptor socketAcceptor) {
@@ -67,7 +67,7 @@ class TcpRSocketResponder extends BaseResponder implements Closeable {
 }
 
 class WebSocketRSocketResponder extends BaseResponder implements Closeable {
-  HttpServer httpServer;
+  late HttpServer httpServer;
 
   WebSocketRSocketResponder(
       Uri uri, HttpServer httpServer, SocketAcceptor socketAcceptor) {

--- a/lib/core/stream_id_supplier.dart
+++ b/lib/core/stream_id_supplier.dart
@@ -1,7 +1,7 @@
 class StreamIdSupplier {
   static int MASK = 0x7FFFFFFF;
-  int streamId;
-  int initialValue;
+  int streamId = 0;
+  late int initialValue;
 
   StreamIdSupplier();
 
@@ -18,7 +18,7 @@ class StreamIdSupplier {
     return StreamIdSupplier.streamId(0);
   }
 
-  int nextStreamId(Map<int, dynamic> streamIds) {
+  int? nextStreamId(Map<int, dynamic> streamIds) {
     var nextStreamId;
     do {
       streamId += 2;

--- a/lib/duplex_connection.dart
+++ b/lib/duplex_connection.dart
@@ -1,14 +1,13 @@
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'rsocket.dart';
-
 import 'io/bytes.dart';
+import 'rsocket.dart';
 
 abstract class DuplexConnection implements Closeable, Availability {
   double _availability = 1.0;
-  TcpChunkHandler receiveHandler;
-  CloseHandler closeHandler;
+  TcpChunkHandler? receiveHandler;
+  CloseHandler? closeHandler;
 
   void init();
 
@@ -32,7 +31,7 @@ class TcpDuplexConnection extends DuplexConnection {
   @override
   void init() {
     socket.listen((data) {
-      receiveHandler(data);
+      receiveHandler!(data);
     }, onDone: () {
       close();
     }, onError: (e) {
@@ -45,12 +44,8 @@ class TcpDuplexConnection extends DuplexConnection {
     if (!closed) {
       closed = true;
       _availability = 0.0;
-      if (socket != null) {
-        socket.close();
-      }
-      if (closeHandler != null) {
-        closeHandler();
-      }
+      socket.close();
+      closeHandler?.call();
     }
   }
 
@@ -71,7 +66,7 @@ class WebSocketDuplexConnection extends DuplexConnection {
     webSocket.listen((message) {
       var data = message as List<int>;
       var frameLenBytes = i24ToBytes(data.length);
-      receiveHandler(Uint8List.fromList(frameLenBytes + data));
+      receiveHandler!(Uint8List.fromList(frameLenBytes + data));
     }, onDone: () {
       close();
     }, onError: (e) {
@@ -84,12 +79,8 @@ class WebSocketDuplexConnection extends DuplexConnection {
     if (!closed) {
       closed = true;
       _availability = 0.0;
-      if (webSocket != null) {
-        webSocket.close();
-      }
-      if (closeHandler != null) {
-        closeHandler();
-      }
+      webSocket.close();
+      closeHandler?.call();
     }
   }
 

--- a/lib/io/bytes.dart
+++ b/lib/io/bytes.dart
@@ -20,7 +20,7 @@ class RSocketByteBuffer {
     return buffer;
   }
 
-  int readI8() {
+  int? readI8() {
     if (_readerIndex < _capacity) {
       var value = _data[_readerIndex];
       _readerIndex += 1;
@@ -29,19 +29,19 @@ class RSocketByteBuffer {
     return null;
   }
 
-  int readI16() {
+  int? readI16() {
     return bytesToNumber(readBytes(2));
   }
 
-  int readI24() {
+  int? readI24() {
     return bytesToNumber(readBytes(3));
   }
 
-  int readI32() {
+  int? readI32() {
     return bytesToNumber(readBytes(4));
   }
 
-  int readI64() {
+  int? readI64() {
     return bytesToNumber(readBytes(8));
   }
 
@@ -172,7 +172,7 @@ Uint8List i16ToBytes(int value) {
   return Uint8List(2)..buffer.asByteData().setUint16(0, value, Endian.big);
 }
 
-int bytesToNumber(List<int> data) {
+int? bytesToNumber(List<int> data) {
   if (data.isNotEmpty) {
     var value = 0;
     data.forEach((element) => value = (value * 256) + element);

--- a/lib/metadata/wellknown_mimetype.dart
+++ b/lib/metadata/wellknown_mimetype.dart
@@ -3,15 +3,15 @@ class WellKnownMimeType {
     return MIME_TYPES.containsKey(id);
   }
 
-  static bool isWellKnownType(String mimeType) {
+  static bool isWellKnownType(String? mimeType) {
     return MIME_TYPES.containsKey(mimeType);
   }
 
-  static String getMimeType(int id) {
+  static String? getMimeType(int id) {
     return MIME_TYPES[id];
   }
 
-  static int getMimeTypeId(String mimeType) {
+  static int? getMimeTypeId(String? mimeType) {
     return MIME_TYPES[mimeType];
   }
 

--- a/lib/payload.dart
+++ b/lib/payload.dart
@@ -2,8 +2,8 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 class Payload {
-  Uint8List metadata;
-  Uint8List data;
+  Uint8List? metadata;
+  Uint8List? data;
 
   Payload();
 
@@ -13,16 +13,16 @@ class Payload {
       : metadata = Uint8List.fromList(utf8.encode(metadata)),
         data = Uint8List.fromList(utf8.encode(data));
 
-  String getMetadataUtf8() {
+  String? getMetadataUtf8() {
     if (metadata != null) {
-      return utf8.decode(metadata);
+      return utf8.decode(metadata!);
     }
     return null;
   }
 
-  String getDataUtf8() {
+  String? getDataUtf8() {
     if (data != null) {
-      return utf8.decode(data);
+      return utf8.decode(data!);
     }
     return null;
   }

--- a/lib/route/reflection.dart
+++ b/lib/route/reflection.dart
@@ -1,15 +1,16 @@
 import 'dart:mirrors';
 
 import '../rsocket.dart';
+import 'package:collection/collection.dart' show IterableExtension;
 
-RSocketService getRSocketServiceAnnotation(dynamic instance) {
+RSocketService? getRSocketServiceAnnotation(dynamic instance) {
   final DeclarationMirror clazzDeclaration = reflectClass(instance.runtimeType);
   final classMirror = reflectClass(RSocketService);
-  final annotationInstanceMirror = clazzDeclaration.metadata
-      .firstWhere((d) => d.type == classMirror, orElse: () => null);
+  final annotationInstanceMirror =
+      clazzDeclaration.metadata.firstWhereOrNull((d) => d.type == classMirror);
   if (annotationInstanceMirror == null) {
     print('Annotation is not on this class');
     return null;
   }
-  return annotationInstanceMirror.reflectee as RSocketService;
+  return annotationInstanceMirror.reflectee as RSocketService?;
 }

--- a/lib/route/rsocket_service_proxy.dart
+++ b/lib/route/rsocket_service_proxy.dart
@@ -3,13 +3,13 @@ import 'package:rsocket/route/reflection.dart';
 import '../rsocket.dart';
 
 typedef RSocketCallHandler = dynamic Function(
-    RSocketService rsocketServiceAnnotation,
+    RSocketService? rsocketServiceAnnotation,
     String methodName,
     List<dynamic> params);
 
 class RSocketServiceStub {
-  RSocketCallHandler rsocketCallHandler;
-  RSocketService rsocketServiceAnnotation;
+  RSocketCallHandler? rsocketCallHandler;
+  RSocketService? rsocketServiceAnnotation;
 
   @override
   dynamic noSuchMethod(Invocation invocation) {
@@ -23,9 +23,9 @@ class RSocketServiceStub {
       methodName = methodName.substring(8, methodName.length - 2);
     }
     if (rsocketCallHandler != null) {
-      return rsocketCallHandler(
+      return rsocketCallHandler!(
           rsocketServiceAnnotation, methodName, invocation.positionalArguments);
     }
-    throw ('rsocketCallHandler is null for ${rsocketServiceAnnotation.name}');
+    throw ('rsocketCallHandler is null for ${rsocketServiceAnnotation!.name}');
   }
 }

--- a/lib/route/rsocket_service_router.dart
+++ b/lib/route/rsocket_service_router.dart
@@ -21,11 +21,11 @@ class RSocketServiceRouter {
   dynamic invokeService(String serviceName, String method, dynamic params) {
     var instanceMirror = instanceMirrors[serviceName];
     if (params == null) {
-      return instanceMirror.invoke(Symbol(method), []).reflectee;
+      return instanceMirror!.invoke(Symbol(method), []).reflectee;
     } else if (params is List) {
-      return instanceMirror.invoke(Symbol(method), params).reflectee;
+      return instanceMirror!.invoke(Symbol(method), params).reflectee;
     } else {
-      return instanceMirror.invoke(Symbol(method), [params]).reflectee;
+      return instanceMirror!.invoke(Symbol(method), [params]).reflectee;
     }
   }
 }

--- a/lib/rsocket.dart
+++ b/lib/rsocket.dart
@@ -1,10 +1,10 @@
 import 'payload.dart';
 
-typedef RequestResponse = Future<Payload> Function(Payload payload);
-typedef FireAndForget = Future<void> Function(Payload payload);
-typedef RequestStream = Stream<Payload> Function(Payload payload);
+typedef RequestResponse = Future<Payload> Function(Payload? payload);
+typedef FireAndForget = Future<void> Function(Payload? payload);
+typedef RequestStream = Stream<Payload?> Function(Payload? payload);
 typedef RequestChannel = Stream<Payload> Function(Stream<Payload> payloads);
-typedef MetadataPush = Future<void> Function(Payload payload);
+typedef MetadataPush = Future<void> Function(Payload? payload);
 typedef RSocketClose = void Function();
 
 abstract class Closeable {
@@ -16,16 +16,16 @@ abstract class Availability {
 }
 
 class RSocket implements Closeable, Availability {
-  RequestResponse requestResponse =
-      (Payload payload) => Future.error(Exception('Unsupported'));
-  FireAndForget fireAndForget =
-      (Payload payload) => Future.error(Exception('Unsupported'));
-  RequestStream requestStream =
-      (Payload payload) => Stream.error(Exception('Unsupported'));
-  RequestChannel requestChannel =
+  RequestResponse? requestResponse =
+      (Payload? payload) => Future.error(Exception('Unsupported'));
+  FireAndForget? fireAndForget =
+      (Payload? payload) => Future.error(Exception('Unsupported'));
+  RequestStream? requestStream =
+      (Payload? payload) => Stream.error(Exception('Unsupported'));
+  RequestChannel? requestChannel =
       (Stream<Payload> payloads) => Stream.error(Exception('Unsupported'));
-  MetadataPush metadataPush =
-      (Payload payload) => Future.error(Exception('Unsupported'));
+  MetadataPush? metadataPush =
+      (Payload? payload) => Future.error(Exception('Unsupported'));
 
   @override
   void close() {}
@@ -54,7 +54,7 @@ class RSocket implements Closeable, Availability {
   }
 }
 
-typedef SocketAcceptor = RSocket Function(
+typedef SocketAcceptor = RSocket? Function(
     ConnectionSetupPayload setup, RSocket sendingSocket);
 
 SocketAcceptor requestResponseAcceptor(RequestResponse requestResponse) {
@@ -76,9 +76,9 @@ SocketAcceptor requestStreamAcceptor(RequestStream requestStream) {
 }
 
 class RSocketService {
-  final String group;
+  final String? group;
   final String name;
-  final String version;
+  final String? version;
 
   const RSocketService(this.name, [this.version, this.group]);
 }

--- a/lib/rsocket_connector.dart
+++ b/lib/rsocket_connector.dart
@@ -8,13 +8,13 @@ import 'core/rsocket_requester.dart';
 import 'duplex_connection.dart';
 
 class RSocketConnector {
-  Payload payload;
+  Payload? payload;
   int keepAliveInterval = 20;
   int keepAliveMaxLifeTime = 90;
   String _dataMimeType = 'application/json';
   String _metadataMimeType = 'message/x.rsocket.composite-metadata.v0';
-  ErrorConsumer _errorConsumer;
-  SocketAcceptor _acceptor;
+  ErrorConsumer? _errorConsumer;
+  SocketAcceptor? _acceptor;
 
   RSocketConnector.create();
 
@@ -59,7 +59,7 @@ class RSocketConnector {
           RSocketRequester('requester', connectionSetupPayload, conn);
       if (_acceptor != null) {
         rsocketRequester.responder =
-            _acceptor(connectionSetupPayload, rsocketRequester);
+            _acceptor!(connectionSetupPayload, rsocketRequester);
         if (rsocketRequester.responder == null) {
           rsocketRequester.close();
           return Future.error(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,12 +1,13 @@
 name: rsocket
-version: 0.1.2
+version: 1.0.0
 description: RSocket for Dart
 homepage: https://github.com/rsocket/rsocket-dart
 repository: https://github.com/rsocket/rsocket-dart.git
 issue_tracker: https://github.com/rsocket/rsocket-dart/issues
 environment:
-  sdk: '>=2.7.0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  rxdart: ^0.27.1
+  rxdart: ^0.27.2
+  collection: ^1.15.0-nullsafety.4
 dev_dependencies:
-  test: ^1.6.0
+  test: ^1.19.2

--- a/rsocket_client.dart
+++ b/rsocket_client.dart
@@ -3,7 +3,7 @@ import 'package:rsocket/shelf.dart';
 void main() async {
   var rsocket =
       await RSocketConnector.create().connect('tcp://127.0.0.1:42252');
-  var result = await rsocket.requestResponse(Payload.fromText('text/plain', 'Ping'));
+  var result = await rsocket.requestResponse!(Payload.fromText('text/plain', 'Ping'));
   print(result.getDataUtf8());
  /* rsocket.requestStream(Payload.fromText('Ping', '')).listen((payload) {
     print(payload.getDataUtf8());

--- a/rsocket_server.dart
+++ b/rsocket_server.dart
@@ -2,9 +2,9 @@ import 'package:rsocket/shelf.dart';
 
 void main() async {
   const listenUrl = 'tcp://0.0.0.0:42252';
-  var closeable = await RSocketServer.create(requestResponseAcceptor((payload) {
+  await RSocketServer.create(requestResponseAcceptor((payload) {
     return Future.value(
-        Payload.fromText('text/plain', 'Hello ' + payload.getDataUtf8()));
+        Payload.fromText('text/plain', 'Hello ' + payload!.getDataUtf8()!));
   })).bind(listenUrl);
   print('RSocket Server started on ${listenUrl}');
 }

--- a/test/metadata/composite_metadata_test.dart
+++ b/test/metadata/composite_metadata_test.dart
@@ -13,9 +13,9 @@ void main() {
     var compositeMetadata2 = CompositeMetadata.fromU8Array(uint8array);
     compositeMetadata2.forEach((entry) {
       print('mimeType: ' +
-          entry.mimeType +
+          entry.mimeType! +
           ', content: ' +
-          entry.content.length.toString());
+          entry.content!.length.toString());
     });
   });
 }

--- a/test/route/load_balance_test.dart
+++ b/test/route/load_balance_test.dart
@@ -6,7 +6,7 @@ void main() {
   test('load-balance', () async {
     var rsocket = LoadBalanceRSocket();
     await rsocket.refreshUrl(['tcp://127.0.0.1:42252']);
-    var result = await rsocket.requestResponse(Payload.fromText('Ping', ''));
+    var result = await rsocket.requestResponse!(Payload.fromText('Ping', ''));
     print(result.getDataUtf8());
   });
 }

--- a/test/routing/proxy_test.dart
+++ b/test/routing/proxy_test.dart
@@ -13,7 +13,7 @@ class UserService extends RSocketServiceStub {
 
 void main() {
   test('proxy_call', () {
-    RSocketCallHandler handler = (RSocketService rsocketServiceAnnotation,
+    RSocketCallHandler handler = (RSocketService? rsocketServiceAnnotation,
         String methodName, List<dynamic> params) {
       return 'rsocket';
     };


### PR DESCRIPTION
NullSafety support for this library

### Motivation:

In the newest versions null safety is a standard

### Modifications:

- migrate all dart files
- update dependencies 
- increase version to indicate breaking change

### Result:

official nullsafety support of the library. You need to publish the new version
