### PR TITLE
Support for rsocket over websocket in browser

### DIFF
--- a/lib/core/rsocket_requester.dart
+++ b/lib/core/rsocket_requester.dart
@@ -261,10 +261,10 @@ class RSocketRequester extends RSocket {
       case frame_types.REQUEST_RESPONSE:
         var requestResponseFrame = frame as RequestResponseFrame;
         if (responder != null && requestResponseFrame.payload != null) {
-          responder!.requestResponse!(requestResponseFrame.payload)
+          responder!.subscribe!(requestResponseFrame.payload)
               .then((payload) {
             connection.write(
-                FrameCodec.encodePayloadFrame(header.streamId, true, payload));
+                FrameCodec.encodePayloadFrame(header.streamId, false, payload));
           }).catchError((error) {
             var rsocketError = convertToRSocketException(error);
             connection.write(FrameCodec.encodeErrorFrame(

--- a/lib/core/rsocket_responder.dart
+++ b/lib/core/rsocket_responder.dart
@@ -1,4 +1,6 @@
-import 'dart:io';
+
+
+import 'package:universal_io/io.dart';
 
 import '../core/rsocket_requester.dart';
 import '../duplex_connection.dart';

--- a/lib/io/bytes.dart
+++ b/lib/io/bytes.dart
@@ -155,7 +155,16 @@ class RSocketByteBuffer {
 }
 
 Uint8List i64ToBytes(int value) {
-  return Uint8List(8)..buffer.asByteData().setUint64(0, value, Endian.big);
+  //because of browser limitations
+  int l = value;
+  var b = BytesBuilder();
+  for (int i = 7; i >= 0; i--) {
+    b.addByte(l & 0xFF);
+
+    l >>= 8;
+  }
+  return Uint8List.fromList(b.toBytes().reversed.toList());
+  //return Uint8List(8)..buffer.asByteData().setUint64(0, value, Endian.big);
 }
 
 Uint8List i32ToBytes(int value) {

--- a/lib/rsocket.dart
+++ b/lib/rsocket.dart
@@ -26,7 +26,7 @@ class RSocket implements Closeable, Availability {
       (Stream<Payload> payloads) => Stream.error(Exception('Unsupported'));
   MetadataPush? metadataPush =
       (Payload? payload) => Future.error(Exception('Unsupported'));
-
+  RequestResponse? subscribe= (Payload? payload)=> Future.error(Exception('Unsupported'));
   @override
   void close() {}
 

--- a/lib/rsocket_server.dart
+++ b/lib/rsocket_server.dart
@@ -1,4 +1,5 @@
-import 'dart:io';
+
+import 'package:universal_io/io.dart';
 
 import 'core/rsocket_responder.dart';
 import 'rsocket.dart';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ issue_tracker: https://github.com/rsocket/rsocket-dart/issues
 environment:
   sdk: '>=2.12.0 <3.0.0'
 dependencies:
-  rxdart: ^0.27.2
-  collection: ^1.15.0-nullsafety.4
+  web_socket_channel:
+  universal_io:
 dev_dependencies:
   test: ^1.19.2


### PR DESCRIPTION
Support for rsocket over websocket in browser & Addition of server push  via "subscribe" function in RSocket class


### Motivation:

Current implementation of the client does not work in browser. 
Current implementation of the client does not support server push.

### Modifications:

1. Changed underlying websocket implementation  with one which can be used in browser
2. Removed dart:io dependencies which are incompatible with browser
3. Added "subscribe" callback which can be used in "server push" scenario

### Result:

RSocket over websocket communication from browser
Notifications about server push
