### PR TITLE
time is in seconds

### DIFF
--- a/lib/rsocket_connector.dart
+++ b/lib/rsocket_connector.dart
@@ -1,11 +1,10 @@
 import 'dart:typed_data';
 
 import 'core/rsocket_error.dart';
-import 'payload.dart';
-import 'rsocket.dart';
-
 import 'core/rsocket_requester.dart';
 import 'duplex_connection.dart';
+import 'payload.dart';
+import 'rsocket.dart';
 
 class RSocketConnector {
   Payload? payload;
@@ -48,8 +47,8 @@ class RSocketConnector {
   Future<RSocket> connect(String url) async {
     TcpChunkHandler handler = (Uint8List chunk) {};
     var connectionSetupPayload = ConnectionSetupPayload()
-      ..keepAliveInterval = keepAliveInterval * 1000
-      ..keepAliveMaxLifetime = keepAliveMaxLifeTime * 1000
+      ..keepAliveInterval = keepAliveInterval
+      ..keepAliveMaxLifetime = keepAliveMaxLifeTime
       ..metadataMimeType = _metadataMimeType
       ..dataMimeType = _dataMimeType
       ..data = payload?.data


### PR DESCRIPTION
keep alive is multiplying the passed value with 1000, which means converting them into milliseconds. Timer is started in seconds https://github.com/rsocket/rsocket-dart/blob/master/lib/core/rsocket_requester.dart#L156, so it makes no sense to convert the values. Also the default values are defined in seconds. 