### PR TITLE
feat: add missing error consumer setter on connector

### DIFF
--- a/lib/rsocket_connector.dart
+++ b/lib/rsocket_connector.dart
@@ -37,6 +37,11 @@ class RSocketConnector {
     return this;
   }
 
+  RSocketConnector errorConsumer(ErrorConsumer errorConsumer) {
+    _errorConsumer = errorConsumer;
+    return this;
+  }
+
   // set the keep alive, and unit is second
   RSocketConnector keepAlive(int interval, int maxLifeTime) {
     this.keepAliveInterval = interval;


### PR DESCRIPTION
Currently, there is no way to receive and/or handle setup rejection errors because the error consumer of the RSocketConnector is always null

### Motivation:
The `connect` function of the `RSocketConnector` [sets](https://github.com/rsocket/rsocket-dart/blob/f31cc6e24f4a3cfda711f459e8cb78b446a62245/lib/rsocket_connector.dart#L70) the `errorConsumer` while the `receiveFrame` function of the `RSocketRequester` [passes](https://github.com/rsocket/rsocket-dart/blob/f31cc6e24f4a3cfda711f459e8cb78b446a62245/lib/core/rsocket_requester.dart#L244) an error frame to the `errorConsumer` to handle the error. The problem is that the `_errorConsumer` of the `RSocketConnecter` has no setter and will always be null. So, users will not be able to receive and/or handle the error, for example when they receive a setup rejection error.

### Modifications:
Adds a setter for the RSocketConnector's error consumer.

### Result:
Now users can receive & handle setup errors correctly
