### PR TITLE
Bugfix for "Payload.fromJson" factory method

### DIFF
--- a/lib/payload.dart
+++ b/lib/payload.dart
@@ -35,7 +35,7 @@ class Payload {
       payload.metadata = Uint8List.fromList(json['metadata'].cast<int>());
     }
     if (json['data'] != null) {
-      payload.metadata = Uint8List.fromList(json['data'].cast<int>());
+      payload.data = Uint8List.fromList(json['data'].cast<int>());
     }
     return payload;
   }


### PR DESCRIPTION
BugFix. Payload data is populated with metadata

### Motivation:

It's a bug. 

Instead of assigning payload data to the `Payload.data` field, it is instead incorrectly assigned to the metadata field.

### Modifications:

Corrected the field assignment. 

### Result:

The payload data is now assigned to the correct field.
